### PR TITLE
removal of the civo.team_id in favour of civo.account_id, civo.permissions, civo.permissions_url

### DIFF
--- a/contrib/local-environment/oauth2-proxy-civo.cfg
+++ b/contrib/local-environment/oauth2-proxy-civo.cfg
@@ -12,4 +12,6 @@ redirect_url="http://localtest.me/oauth2/callback"
 
 provider="civo"
 provider_display_name="Civo"
-civo_team="853ab4cf-f6d5-456d-ae5b-f06a34b29d75"
+civo_account="853ab4cf-f6d5-456d-ae5b-f06a34b29d75"
+civo_permissions="instance.*,instance.updater,instance.admin,*.*"
+civo_permissions_url="https://api.civo.com/v2/permissions"

--- a/docs/docs/configuration/providers/civo.md
+++ b/docs/docs/configuration/providers/civo.md
@@ -19,9 +19,17 @@ To use the provider, pass the following options:
 ```
 
 
-3. Restrict based on team_id
-* Using a flag `civo-team`(team_id) can restrict access to a specific team.
+3. Restrict based on account_id
+* Using a flag `civo-account`(account_id) you can restrict access to a specific account.
 
 An example config can be found at `contrib/local-environment/oauth2-proxy-civo.cfg`.
 Alternatively, set the equivalent options in the config file. The redirect URL defaults to 
 `https://<requested host header>/oauth2/callback`. If you need to change it, you can use the `--redirect-url` command-line option.
+
+4. Restrict based on civo_permissions
+* Using a flag `civo-permissions` (civo_permissions) you can restrict access to a given set of permissions
+
+An example config can be found at `contrib/local-environment/oauth2-proxy-civo.cfg`.
+Alternatively, set the equivalent options in the config file. 
+
+* Using a flag `civo-permissions-url` (civo_permissions_url) you can pass the URL to call to get the permissions of a given user in a specified account

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	golang.org/x/text v0.16.0 // indirect
 	golang.org/x/tools v0.22.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240617180043-68d350f18fd4 // indirect
-	google.golang.org/grpc v1.64.0 // indirect
+	google.golang.org/grpc v1.64.1 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -357,6 +357,8 @@ google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/grpc v1.64.0 h1:KH3VH9y/MgNQg1dE7b3XfVK0GsPSIzJwdF617gUSbvY=
 google.golang.org/grpc v1.64.0/go.mod h1:oxjF8E3FBnjp+/gVFYdWacaLDx9na1aqy9oovLpxQYg=
+google.golang.org/grpc v1.64.1 h1:LKtvyfbX3UGVPFcGqJ9ItpVWW6oN/2XqTxfAnwRRXiA=
+google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvyjeP0=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -490,7 +490,9 @@ type LegacyProvider struct {
 	AzureGraphGroupField                   string   `flag:"azure-graph-group-field" cfg:"azure_graph_group_field"`
 	BitbucketTeam                          string   `flag:"bitbucket-team" cfg:"bitbucket_team"`
 	BitbucketRepository                    string   `flag:"bitbucket-repository" cfg:"bitbucket_repository"`
-	CivoTeam                               string   `flag:"civo-team" cfg:"civo_team"`
+	CivoAccount                            string   `flag:"civo-account" cfg:"civo_account"`
+	CivoPermissions                        []string `flag:"civo-permissions" cfg:"civo_permissions" `
+	CivoPermissionsURL                     string   `flag:"civo-permissions-url" cfg:"civo_permissions_url"`
 	GitHubOrg                              string   `flag:"github-org" cfg:"github_org"`
 	GitHubTeam                             string   `flag:"github-team" cfg:"github_team"`
 	GitHubRepo                             string   `flag:"github-repo" cfg:"github_repo"`
@@ -553,7 +555,9 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.String("azure-graph-group-field", "", "configures the group field to be used when building the groups list(`id` or `displayName`. Default is `id`) from Microsoft Graph(available only for v2.0 oidc url). Based on this value, the `allowed-group` config values should be adjusted accordingly. If using `id` as group field, `allowed-group` should contains groups IDs, if using `displayName` as group field, `allowed-group` should contains groups name")
 	flagSet.String("bitbucket-team", "", "restrict logins to members of this team")
 	flagSet.String("bitbucket-repository", "", "restrict logins to user with access to this repository")
-	flagSet.String("civo-team", "", "restrict logins to members of this team")
+	flagSet.String("civo-account", "", "restrict logins to members of this account")
+	flagSet.StringSlice("civo-permissions", []string{}, "restrict logins to civo users with the given set of permissions")
+	flagSet.String("civo-permissions-url", "", "url to get the user permissions in a given account")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
 	flagSet.String("github-team", "", "restrict logins to members of this team")
 	flagSet.String("github-repo", "", "restrict logins to collaborators of this repository")
@@ -746,7 +750,9 @@ func (l *LegacyProvider) convert() (Providers, error) {
 
 	case "civo":
 		provider.CivoConfig = CivoOptions{
-			Team: l.CivoTeam,
+			Account:        l.CivoAccount,
+			Permissions:    l.CivoPermissions,
+			PermissionsURL: l.CivoPermissionsURL,
 		}
 	case "google":
 		if len(l.GoogleGroupsLegacy) != 0 && !reflect.DeepEqual(l.GoogleGroupsLegacy, l.GoogleGroups) {

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -174,8 +174,12 @@ type BitbucketOptions struct {
 }
 
 type CivoOptions struct {
-	// Team sets restrict logins to members of this team
-	Team string `json:"team,omitempty"`
+	// Account sets restrict logins to members of this account
+	Account string `json:"account,omitempty"`
+	// Permissions is a comma-separated set of permissions to restrict login with
+	Permissions []string `json:"permissions,omitempty"`
+	// PermissionsURL is the URL to get the user permissions under a given account
+	PermissionsURL string `json:"permissions_url,omitempty"`
 }
 
 type GitHubOptions struct {

--- a/providers/civo.go
+++ b/providers/civo.go
@@ -35,7 +35,7 @@ var (
 	CivoDefaultLoginURL = &url.URL{
 		Scheme: "https",
 		Host:   "auth.civo.com",
-		Path:   "authorize",
+		Path:   "v2/authorize",
 	}
 
 	// Default Redeem URL for Civo.
@@ -43,7 +43,7 @@ var (
 	CivoDefaultRedeemURL = &url.URL{
 		Scheme: "https",
 		Host:   "auth.civo.com",
-		Path:   "token",
+		Path:   "v2/token",
 	}
 
 	// Default Profile URL for Civo.
@@ -51,7 +51,7 @@ var (
 	CivoDefaultProfileURL = &url.URL{
 		Scheme: "https",
 		Host:   "auth.civo.com",
-		Path:   "userinfo",
+		Path:   "v2/userinfo",
 	}
 )
 

--- a/providers/civo.go
+++ b/providers/civo.go
@@ -143,9 +143,16 @@ func (p *CivoProvider) EnrichSession(ctx context.Context, s *sessions.SessionSta
 	return nil
 }
 
+// Permission is the struct representing the Civo permission
+type Permission struct {
+	Code        string `json:"code"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
 // returns the set of permissions the user has in the given account (it's the sum of the permissions for each team_membership)
 // the information of the user is in the accessToken claims, meanwhile the account is taken from the configuration of the oauth-proxy
-func (p *CivoProvider) getUserPermissionsInAccount(ctx context.Context, accessToken string) (permissions []string, err error) {
+func (p *CivoProvider) getUserPermissionsInAccount(ctx context.Context, accessToken string) (permissions []Permission, err error) {
 
 	// adding the account_id as query param for the request
 	endpoint := fmt.Sprintf("%s%saccount_id=%s", p.PermissionsURL, joinerChar(p.PermissionsURL), p.Account)
@@ -169,9 +176,9 @@ func joinerChar(url string) string {
 }
 
 // returns true if the current session returns a set of permissions having a match with the requiredPermissions
-func (p *CivoProvider) isUserAllowed(userPermissions []string) bool {
+func (p *CivoProvider) isUserAllowed(userPermissions []Permission) bool {
 	for _, perm := range userPermissions {
-		if _, found := p.PermissionsMap[perm]; found {
+		if _, found := p.PermissionsMap[perm.Code]; found {
 			return true
 		}
 	}

--- a/providers/civo.go
+++ b/providers/civo.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/url"
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
@@ -13,7 +14,12 @@ import (
 // CivoProvider represents a Civo based Identity Provider
 type CivoProvider struct {
 	*ProviderData
-	Team string
+	// Account is the account_id to restrict access to
+	Account string
+	// PermissionsMap is the map of permissions to restrict access to
+	PermissionsMap map[string]struct{}
+	// PermissionsURL is the url to verify the user permissions in the specified account
+	PermissionsURL string
 }
 
 var _ Provider = (*CivoProvider)(nil)
@@ -61,7 +67,18 @@ func NewCivoProvider(p *ProviderData, opts options.CivoOptions) *CivoProvider {
 	})
 	p.getAuthorizationHeaderFunc = makeOIDCHeader
 
-	return &CivoProvider{ProviderData: p, Team: opts.Team}
+	// using a map to avoid nested cycle to every request. The key of the map is the permission string
+	requiredPermissionsMap := make(map[string]struct{}, 0)
+	for _, perm := range opts.Permissions {
+		requiredPermissionsMap[perm] = struct{}{}
+	}
+
+	return &CivoProvider{
+		ProviderData:   p,
+		Account:        opts.Account,
+		PermissionsMap: requiredPermissionsMap,
+		PermissionsURL: opts.PermissionsURL,
+	}
 }
 
 // GetEmailAddress returns the Account email address
@@ -83,8 +100,6 @@ func (p *CivoProvider) GetEmailAddress(ctx context.Context, s *sessions.SessionS
 	if err != nil {
 		return "", err
 	}
-
-	// p.setTeam(team)
 
 	return email, nil
 }
@@ -109,16 +124,56 @@ func (p *CivoProvider) EnrichSession(ctx context.Context, s *sessions.SessionSta
 		return err
 	}
 
-	team, err := json.GetPath("team_id").String()
+	user, err := json.GetPath("user_id").String()
 	if err != nil {
 		return err
 	}
 
-	if team != p.Team {
-		return errors.New("user isn't part of the required team")
+	permissions, err := p.getUserPermissionsInAccount(ctx, s.AccessToken)
+	if err != nil {
+		return err
 	}
 
-	s.Groups = append(s.Groups, team)
+	if !p.isUserAllowed(permissions) {
+		return fmt.Errorf("user %s in account %s has no sufficient permissions", user, p.Account)
+	}
+
+	s.Groups = append(s.Groups, p.Account) // FIXME: is that correct? What is this Groups meant for? Should it be the user instead
 
 	return nil
+}
+
+// returns the set of permissions the user has in the given account (it's the sum of the permissions for each team_membership)
+// the information of the user is in the accessToken claims, meanwhile the account is taken from the configuration of the oauth-proxy
+func (p *CivoProvider) getUserPermissionsInAccount(ctx context.Context, accessToken string) (permissions []string, err error) {
+
+	// adding the account_id as query param for the request
+	endpoint := fmt.Sprintf("%s%saccount_id=%s", p.PermissionsURL, joinerChar(p.PermissionsURL), p.Account)
+
+	if err := requests.New(endpoint).
+		WithContext(ctx).
+		WithHeaders(makeOIDCHeader(accessToken)).
+		Do().
+		UnmarshalInto(&permissions); err != nil {
+		return nil, err
+	}
+
+	return permissions, nil
+}
+
+func joinerChar(url string) string {
+	if hasQueryParams(url) {
+		return "&"
+	}
+	return "?"
+}
+
+// returns true if the current session returns a set of permissions having a match with the requiredPermissions
+func (p *CivoProvider) isUserAllowed(userPermissions []string) bool {
+	for _, perm := range userPermissions {
+		if _, found := p.PermissionsMap[perm]; found {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removal of the `civo.team_id` and substitution with the `civo.account_id` `civo.permissions` and `civo.permissions_url`.

## Motivation and Context

Modifying the OIDC civo provider to let the access token have the user_id information only brought to the following changes needed:
- team_id and account_id have been removed from the JWT claims
- user_id is fetched from the JWT
- the JWT is used to call a `v2/permissions` endpoint to validate the user permissions against the account with which the pod is configured

## How Has This Been Tested?

Waiting for an e2e test test along with the new version of the civo api.

## Checklist:

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
- [X] I have written tests for my code changes.
